### PR TITLE
Update Go versions in build workflow, drop 1.24

### DIFF
--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.24', '1.25', '1.26' ]
+        go: [ '1.25', '1.26' ]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6


### PR DESCRIPTION
Removed Go version 1.24 from the build matrix.